### PR TITLE
Update NPT Water example

### DIFF
--- a/NPT/water_580_00_K/in.conf
+++ b/NPT/water_580_00_K/in.conf
@@ -88,25 +88,25 @@ AdjSteps	1000
 ################################
 # MOVE FREQUENCY              
 ################################
-DisFreq               0.60  
-RotFreq		      0.28
+DisFreq             0.49  
+RotFreq		          0.49
 RegrowthFreq	      0.10
-VolFreq		      0.02
+VolFreq		          0.02
 
 ################################
 # BOX DIMENSION #, X, Y, Z
 ################################
-CellBasisVector1 0	23.00	0.00	0.00
-CellBasisVector2 0	0.00	23.00	0.00
-CellBasisVector3 0	0.00	0.00	23.00
+CellBasisVector1 0	24.00	0.00	0.00
+CellBasisVector2 0	0.00	24.00	0.00
+CellBasisVector3 0	0.00	0.00	24.00
 
 ##############################
 # CBMC TRIALS
 ##############################
 CBMC_First   10     
 CBMC_Nth     4
-CBMC_Ang     100
-CBMC_Dih     20
+CBMC_Ang     50
+CBMC_Dih     1
 
 
 ############################################################################
@@ -121,7 +121,7 @@ OutputName  SPCE_580_00_K_RESTART
 #####################################
 # enable, frequency           
 #####################################
-CoordinatesFreq    true   1000000
+DCDFreq    true   1000000
 RestartFreq  	   true   1000000
 ConsoleFreq        true   100000
 BlockAverageFreq   true   100000

--- a/NPT/water_580_00_K/in.conf
+++ b/NPT/water_580_00_K/in.conf
@@ -1,12 +1,7 @@
 ########################
-## Init File 
+## GOMC Control File 
 ## 
-## IMPROVEMENTS
-## - Compacts inputs into one line
-## - Suggestion: edit inline with (insert key)
 ##
-## To-Do 
-## (make editor + XML version)
 ########################
 
 ############################################################################
@@ -14,12 +9,12 @@
 ############################################################################
 
 #########################
-# enable, step
+# RESTART: true, false
 #########################
 Restart	 	false
 
 ####################################
-# kind {RESTART, RANDOM, INTSEED}
+# RANDOM, INTSEED
 ####################################
 PRNG		INTSEED
 Random_Seed	123	
@@ -27,34 +22,31 @@ Random_Seed	123
 ####################################
 # FORCE FIELD
 ####################################
-ParaTypeEXOTIC	 off
+ParaTypeMIE	     off
 ParaTypeCHARMM	 on
 Parameters     	 ./../../common/Par_SPCE_Charmm.inp
 
 ####################################
-# INPUT PDB FILES
+# INPUT PDB FILE
 ####################################
 Coordinates 0 ./START_BOX_0.pdb
 
 ####################################
-# INPUT PSF FILES
+# INPUT PSF FILE
 ####################################
 Structure 0 ./START_BOX_0.psf
-
-
 
 ############################################################################
 #  =======--------------------- SYSTEM --------------------------===========
 ############################################################################
 
 ##################################
-# GEMC TYPE (DEFULT IS NVT_GEMC)  
+# Define pressure for NPT simulation  
 ##################################
 Pressure  70.158
 
-
 #############################
-# SIMULATION CONDITION   
+# SIMULATION CONDITIONS   
 #############################
 Temperature     580.00
 Potential       VDW 
@@ -65,7 +57,7 @@ Exclude 	1-4
 RcutCoulomb  0  10
 
 #############################
-# ELECTROSTATIC   
+# ELECTROSTATICS   
 #############################
 ElectroStatic   true
 Ewald		true
@@ -89,12 +81,12 @@ AdjSteps	1000
 # MOVE FREQUENCY              
 ################################
 DisFreq             0.49  
-RotFreq		          0.49
+RotFreq		          0.39
 RegrowthFreq	      0.10
 VolFreq		          0.02
 
 ################################
-# BOX DIMENSION #, X, Y, Z
+# BOX DIMENSIONS #, X, Y, Z
 ################################
 CellBasisVector1 0	24.00	0.00	0.00
 CellBasisVector2 0	0.00	24.00	0.00
@@ -114,27 +106,21 @@ CBMC_Dih     1
 ############################################################################
 
 ##########################
-# statistics filename add
+# Define output filename
 ##########################
 OutputName  SPCE_580_00_K_RESTART
 
 #####################################
-# enable, frequency           
+# enable output {true|false} frequency           
 #####################################
 DCDFreq    true   1000000
 RestartFreq  	   true   1000000
 ConsoleFreq        true   100000
 BlockAverageFreq   true   100000
 
-
-################################
-# OutHistSettings
-################################
-
-
-##################################
-# enable: blk avg., fluct.
-##################################
+####################################################
+# enable: block average; instantaneous {true|false}
+####################################################
 OutEnergy         true    true 
 OutPressure       true    true   
 OutMolNum         true    true 


### PR DESCRIPTION
Updated in.conf to increase the initial size of the cell basis vectors to 24 (was 23A), which produces a simulation that is more well behaved (i.e. doesn't explode).  Edited the ratios of Monte Carlo moves to be more representative of how we would actually run the simulation.  Added DCDFreq to the output section.  Cleaned up some of the comments in the input file to reflect the current version. 