### PR TITLE
added Exp6 FF example and notes to all files using mol2 that the residue name must be entered the same as the as in the mol2 file.

### DIFF
--- a/MoSDef-GOMC/Part_11_NPT_GMSO_Exp6_FF_XML_Example/NVT_Example_Exp6_FF_XML_hexane_ua_gmso.ipynb
+++ b/MoSDef-GOMC/Part_11_NPT_GMSO_Exp6_FF_XML_Example/NVT_Example_Exp6_FF_XML_hexane_ua_gmso.ipynb
@@ -2,19 +2,21 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "id": "optical-evolution",
-   "metadata": {},
+   "id": "working-singer",
+   "metadata": {
+    "jp-MarkdownHeadingCollapsed": true
+   },
    "source": [
-    "# GOMC Example for the Mie FF GMSO version NVT Ensemble using MoSDeF [1, 2, 5-10, 13-17]\n",
-    "\n"
+    "# GOMC Example the Exp6 FF GMSO version NVT Ensemble using MoSDeF [1, 2, 5-10, 13-17]"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "working-singer",
+   "id": "optical-evolution",
    "metadata": {},
    "source": [
-    "## Import the required packages and specify the force field (FF), box dimensions, density, and mol ratios [1, 2, 5-10, 13-17]."
+    "# Import the required packages and specify the force field (FF),\n",
+    "# box dimensions, density, and mol ratios [1, 2, 5-10, 13-17]."
    ]
   },
   {
@@ -29,7 +31,8 @@
     "import mosdef_gomc.formats.gmso_charmm_writer as mf_charmm\n",
     "import mosdef_gomc.formats.gmso_gomc_conf_writer as gomc_control\n",
     "\n",
-    "FF_to_use = '../common/gmso_two_propanol_Mie_periodic_dihedral_ua_K_energy_units.xml'\n",
+    "\n",
+    "FF_to_use = '../common/gmso_hexane_Exp6_periodic_dihedral_ua_K_energy_units.xml'\n",
     "\n",
     "liquid_box_length_Ang = 45\n",
     "liquid_box_density_kg_per_m_cubed = 642"
@@ -40,13 +43,13 @@
    "id": "traditional-vocabulary",
    "metadata": {},
    "source": [
-    "# Create the two propanol molecule with residue names.\n",
+    "# Create the hexane molecule with residue names\n",
     "\n",
     "# Generate the lists for the molecule, residue, and residues/molecules force fields [1, 2, 13-17].  \n",
     "\n",
     "## Note: For GOMC, the residue names are treated as molecules, so the residue names must be unique for each different molecule [1, 2, 13-17].\n",
     "\n",
-    "## Note: When importing mol2 files, the residue names (two_propanol.name) must be the same name as in the mol2 file."
+    "## Note: When importing mol2 files, the residue names (hexane.name) must be the same name as in the mol2 file. "
    ]
   },
   {
@@ -56,11 +59,11 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "two_propanol = mb.load('../common/two_propanol_ua.mol2')\n",
-    "two_propanol.name = 'TPR'\n",
+    "hexane = mb.load('../common/hexane.mol2')\n",
+    "hexane.name = 'HEX'\n",
     "\n",
-    "molecule_list = [two_propanol]\n",
-    "residues_list = [two_propanol.name]"
+    "molecule_list = [hexane]\n",
+    "residues_list = [hexane.name]"
    ]
   },
   {
@@ -78,13 +81,15 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "two_propanol_box_liq = mb.fill_box(compound=molecule_list,\n",
-    "                                     density=liquid_box_density_kg_per_m_cubed,\n",
-    "                                     compound_ratio=[1],\n",
-    "                                     box=[liquid_box_length_Ang / 10,\n",
-    "                                          liquid_box_length_Ang / 10,\n",
-    "                                          liquid_box_length_Ang / 10]\n",
-    "                                     )"
+    "hexane_box_liq = mb.fill_box(compound=molecule_list,\n",
+    "                             density=liquid_box_density_kg_per_m_cubed,\n",
+    "                             compound_ratio=[1],\n",
+    "                             box=[\n",
+    "                                 liquid_box_length_Ang / 10,\n",
+    "                                 liquid_box_length_Ang / 10,\n",
+    "                                 liquid_box_length_Ang / 10\n",
+    "                                  ]\n",
+    "                             )"
    ]
   },
   {
@@ -102,11 +107,12 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "charmm = mf_charmm.Charmm(two_propanol_box_liq,\n",
-    "                          'NVT_two_propanol_liq',\n",
-    "                          ff_filename=\"NVT_two_propanol_FF\",\n",
+    "charmm = mf_charmm.Charmm(hexane_box_liq,\n",
+    "                          'NVT_hexane_exp6_liq',\n",
+    "                          ff_filename=\"NVT_hexane_exp6_FF\",\n",
     "                          forcefield_selection=FF_to_use,\n",
     "                          residues= residues_list,\n",
+    "                          atom_type_naming_style=\"general\",\n",
     "                          )"
    ]
   },
@@ -141,6 +147,22 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "af113896",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "ce501ef4-faad-438e-9fd1-c721e48f9780",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "3727f4d8-31a1-453a-820f-8b54829c35ce",
    "metadata": {},
    "outputs": [],
    "source": []

--- a/MoSDef-GOMC/Part_11_NPT_GMSO_Exp6_FF_XML_Example/NVT_Example_Exp6_FF_XML_hexane_ua_gmso.py
+++ b/MoSDef-GOMC/Part_11_NPT_GMSO_Exp6_FF_XML_Example/NVT_Example_Exp6_FF_XML_hexane_ua_gmso.py
@@ -1,4 +1,4 @@
-# GOMC Example for the Mie FF GMSO version NVT Ensemble using MoSDeF [1, 2, 5-10, 13-17]
+# GOMC Example for the Exp6 FF GMSO version NVT Ensemble using MoSDeF [1, 2, 5-10, 13-17]
 
 # Import the required packages and specify the force field (FF),
 # box dimensions, density, and mol ratios [1, 2, 5-10, 13-17].
@@ -8,12 +8,14 @@ import unyt as u
 import mosdef_gomc.formats.gmso_charmm_writer as mf_charmm
 import mosdef_gomc.formats.gmso_gomc_conf_writer as gomc_control
 
-FF_to_use = '../common/gmso_two_propanol_Mie_periodic_dihedral_ua_K_energy_units.xml'
+
+FF_to_use = '../common/gmso_hexane_Exp6_periodic_dihedral_ua_K_energy_units.xml'
 
 liquid_box_length_Ang = 45
 liquid_box_density_kg_per_m_cubed = 642
 
-# Create the two propanol molecule with residue names
+
+# Create the hexane molecule with residue names
 
 # Generate the lists for the molecule, residue, and
 # residues/molecules force fields [1, 2, 13-17].
@@ -21,33 +23,36 @@ liquid_box_density_kg_per_m_cubed = 642
 ## Note: For GOMC, the residue names are treated as molecules,
 # so the residue names must be unique for each different molecule [1, 2, 13-17].
 
-## Note: When importing mol2 files, the residue names (two_propanol.name) must be the same name as in the mol2 file.
+## Note: When importing mol2 files, the residue names (hexane.name) must be the same name as in the mol2 file.
 
-two_propanol = mb.load('../common/two_propanol_ua.mol2')
-two_propanol.name = 'TPR'
+hexane = mb.load('../common/hexane.mol2')
+hexane.name = 'HEX'
 
-molecule_list = [two_propanol]
-residues_list = [two_propanol.name]
+molecule_list = [hexane]
+residues_list = [hexane.name]
 
 ## Build the main liquid simulation box (box 0) for the simulation [1, 2, 13-17]
 
-two_propanol_box_liq = mb.fill_box(compound=molecule_list,
-                                     density=liquid_box_density_kg_per_m_cubed,
-                                     compound_ratio=[1],
-                                     box=[liquid_box_length_Ang / 10,
-                                          liquid_box_length_Ang / 10,
-                                          liquid_box_length_Ang / 10]
-                                     )
+hexane_box_liq = mb.fill_box(compound=molecule_list,
+                             density=liquid_box_density_kg_per_m_cubed,
+                             compound_ratio=[1],
+                             box=[
+                                 liquid_box_length_Ang / 10,
+                                 liquid_box_length_Ang / 10,
+                                 liquid_box_length_Ang / 10
+                                  ]
+                             )
 
 
 # Build the Charmm object, which is required to write the
 # FF (.inp), psf, pdb, and GOMC control files [1, 2, 5-10, 13-17]
 
-charmm = mf_charmm.Charmm(two_propanol_box_liq,
-                          'NVT_two_propanol_liq',
-                          ff_filename="NVT_two_propanol_FF",
+charmm = mf_charmm.Charmm(hexane_box_liq,
+                          'NVT_hexane_exp6_liq',
+                          ff_filename="NVT_hexane_exp6_FF",
                           forcefield_selection=FF_to_use,
                           residues= residues_list,
+                          atom_type_naming_style="general",
                           )
 
 
@@ -61,8 +66,5 @@ charmm.write_pdb()
 
 
 gomc_control.write_gomc_control_file(charmm, 'in_NVT.conf',  'NVT', 100, 300 * u.Kelvin,
-                                     input_variables_dict={}
+                                     input_variables_dict={},
                                      )
-
-
-

--- a/MoSDef-GOMC/Part_11_NPT_GMSO_Exp6_FF_XML_Example/README.md
+++ b/MoSDef-GOMC/Part_11_NPT_GMSO_Exp6_FF_XML_Example/README.md
@@ -1,0 +1,2 @@
+# GOMC Example for the NPT Ensemble using the GMSO FF XML file formate using the Exp6 non-bonded potential via MoSDeF
+

--- a/MoSDef-GOMC/Part_3_GCMC_Example/GCMC_Example_n_pentane_n_hexane_FF.ipynb
+++ b/MoSDef-GOMC/Part_3_GCMC_Example/GCMC_Example_n_pentane_n_hexane_FF.ipynb
@@ -61,7 +61,9 @@
    "source": [
     "## Select the united-atom (UA) molecules mol2 files and set the residue name, molecule types, and box 0 & 1 values.  Box 1 is the reservoir.\n",
     "\n",
-    "## Note: For GOMC, the residue names are treated as molecules, so the residue names must be unique for each different molecule [1, 2, 13-17]."
+    "## Note: For GOMC, the residue names are treated as molecules, so the residue names must be unique for each different molecule [1, 2, 13-17].\n",
+    "\n",
+    "## Note: When importing mol2 files, the residue names (Molecule_A.name and Molecule_B.name) must be the same name as in the mol2 file."
    ]
   },
   {
@@ -364,7 +366,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },
@@ -378,7 +380,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.1"
+   "version": "3.10.0"
   }
  },
  "nbformat": 4,

--- a/MoSDef-GOMC/Part_3_GCMC_Example/GCMC_Example_n_pentane_n_hexane_FF.py
+++ b/MoSDef-GOMC/Part_3_GCMC_Example/GCMC_Example_n_pentane_n_hexane_FF.py
@@ -29,6 +29,8 @@ FF =  Forcefield(name = forcefield_files )
 
 # Note: For GOMC, the residue names are treated as molecules, so the residue names must be unique for each different molecule [1, 2, 13-17].
 
+# Note: When importing mol2 files, the residue names (Molecule_A.name and Molecule_B.name) must be the same name as in the mol2 file.
+
 Molecule_A =mb.load('../common/pentane.mol2')
 FF.apply(Molecule_A)
 Molecule_A.name = 'PEN'

--- a/MoSDef-GOMC/Part_3_GCMC_Example/GCMC_Example_n_pentane_n_hexane_FF_gmso.ipynb
+++ b/MoSDef-GOMC/Part_3_GCMC_Example/GCMC_Example_n_pentane_n_hexane_FF_gmso.ipynb
@@ -51,7 +51,9 @@
    "source": [
     "## Select the united-atom (UA) molecules mol2 files and set the residue name, molecule types, and box 0 & 1 values.  Box 1 is the reservoir.\n",
     "\n",
-    "## Note: For GOMC, the residue names are treated as molecules, so the residue names must be unique for each different molecule [1, 2, 13-17]."
+    "## Note: For GOMC, the residue names are treated as molecules, so the residue names must be unique for each different molecule [1, 2, 13-17].\n",
+    "\n",
+    "## Note: When importing mol2 files, the residue names (Molecule_A.name and Molecule_B.name) must be the same name as in the mol2 file."
    ]
   },
   {
@@ -217,7 +219,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.12"
+   "version": "3.10.0"
   }
  },
  "nbformat": 4,

--- a/MoSDef-GOMC/Part_3_GCMC_Example/GCMC_Example_n_pentane_n_hexane_FF_gmso.py
+++ b/MoSDef-GOMC/Part_3_GCMC_Example/GCMC_Example_n_pentane_n_hexane_FF_gmso.py
@@ -27,6 +27,8 @@ forcefield_files = 'trappe-ua'
 
 # Note: For GOMC, the residue names are treated as molecules, so the residue names must be unique for each different molecule [1, 2, 13-17].
 
+# Note: When importing mol2 files, the residue names (Molecule_A.name and Molecule_B.name) must be the same name as in the mol2 file.
+
 Molecule_A =mb.load('../common/pentane.mol2')
 Molecule_A.name = 'PEN'
 

--- a/MoSDef-GOMC/Part_5_NPT_Example/NPT_Example_n_hexane_water_FF.ipynb
+++ b/MoSDef-GOMC/Part_5_NPT_Example/NPT_Example_n_hexane_water_FF.ipynb
@@ -44,7 +44,9 @@
     "\n",
     "# Generate the list for the molecules, residues, and mol ratios.  Make the dictionaries to customize the bead's atoms names, and set the residues/molecules force fields [1, 2, 13-17].  \n",
     "\n",
-    "## Note: For GOMC, the residue names are treated as molecules, so the residue names must be unique for each different molecule [1, 2, 13-17]. The force field (FF) dictionary (forcefield_files variable) can set each residue with a different FF, by the FF name (via the foyer FF repository) or a specified FF xml file [1, 2, 13-17]."
+    "## Note: For GOMC, the residue names are treated as molecules, so the residue names must be unique for each different molecule [1, 2, 13-17]. The force field (FF) dictionary (forcefield_files variable) can set each residue with a different FF, by the FF name (via the foyer FF repository) or a specified FF xml file [1, 2, 13-17].\n",
+    "\n",
+    "## Note: When importing mol2 files, the residue names (hexane.name) must be the same name as in the mol2 file."
    ]
   },
   {
@@ -187,7 +189,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.12"
+   "version": "3.10.0"
   }
  },
  "nbformat": 4,

--- a/MoSDef-GOMC/Part_5_NPT_Example/NPT_Example_n_hexane_water_FF.py
+++ b/MoSDef-GOMC/Part_5_NPT_Example/NPT_Example_n_hexane_water_FF.py
@@ -24,6 +24,8 @@ water_mol_ratio = 0.5
 # with a different FF, by the FF name (via the foyer FF repository)
 # or a specified FF xml file [1, 2, 13-17].
 
+# Note: When importing mol2 files, the residue names (hexane.name) must be the same name as in the mol2 file.
+
 forcefield_files_hexane = 'trappe-ua'
 hexane =mb.load('../common/hexane.mol2')
 hexane.energy_minimize(forcefield = forcefield_files_hexane , steps=10**4)

--- a/MoSDef-GOMC/Part_5_NPT_Example/NPT_Example_n_hexane_water_FF_gmso.ipynb
+++ b/MoSDef-GOMC/Part_5_NPT_Example/NPT_Example_n_hexane_water_FF_gmso.ipynb
@@ -44,7 +44,9 @@
     "\n",
     "# Generate the list for the molecules, residues, and mol ratios.  Make the dictionaries to customize the bead's atoms names, and set the residues/molecules force fields [1, 2, 13-17].  \n",
     "\n",
-    "## Note: For GOMC, the residue names are treated as molecules, so the residue names must be unique for each different molecule [1, 2, 13-17]. The force field (FF) dictionary (forcefield_files variable) can set each residue with a different FF, by the FF name (via the foyer FF repository) or a specified FF xml file [1, 2, 13-17]."
+    "## Note: For GOMC, the residue names are treated as molecules, so the residue names must be unique for each different molecule [1, 2, 13-17]. The force field (FF) dictionary (forcefield_files variable) can set each residue with a different FF, by the FF name (via the foyer FF repository) or a specified FF xml file [1, 2, 13-17].\n",
+    "\n",
+    "## Note: When importing mol2 files, the residue names (hexane.name) must be the same name as in the mol2 file."
    ]
   },
   {
@@ -177,7 +179,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.12"
+   "version": "3.10.0"
   }
  },
  "nbformat": 4,

--- a/MoSDef-GOMC/Part_5_NPT_Example/NPT_Example_n_hexane_water_FF_gmso.py
+++ b/MoSDef-GOMC/Part_5_NPT_Example/NPT_Example_n_hexane_water_FF_gmso.py
@@ -24,6 +24,8 @@ water_mol_ratio = 0.5
 # with a different FF, by the FF name (via the foyer FF repository)
 # or a specified FF xml file [1, 2, 13-17].
 
+## Note: When importing mol2 files, the residue names (hexane.name) must be the same name as in the mol2 file.
+
 forcefield_files_hexane = 'trappe-ua'
 hexane =mb.load('../common/hexane.mol2')
 hexane.name = 'HEX'

--- a/MoSDef-GOMC/Part_6_NVT_Example/NVT_Example_pentane_hexane.ipynb
+++ b/MoSDef-GOMC/Part_6_NVT_Example/NVT_Example_pentane_hexane.ipynb
@@ -18,19 +18,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 26,
+   "execution_count": null,
    "id": "structured-depression",
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "/Users/brad/Programs/anaconda3/envs/GOMC_MOSDEF/lib/python3.9/site-packages/ipykernel/ipkernel.py:283: DeprecationWarning: `should_run_async` will not call `transform_cell` automatically in the future. Please pass the result to `transformed_cell` argument and any exception that happen during thetransform in `preprocessing_exc_tuple` in IPython 7.17 and above.\n",
-      "  and should_run_async(code)\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "import mbuild as mb\n",
     "import mbuild.formats.charmm_writer as mf_charmm\n",
@@ -54,52 +45,17 @@
     "\n",
     "# Generate the lists for the molecules, residues, and mol ratios,  residues/molecules force fields [1, 2, 13-17].  \n",
     "\n",
-    "## Note: For GOMC, the residue names are treated as molecules, so the residue names must be unique for each different molecule [1, 2, 13-17]."
+    "## Note: For GOMC, the residue names are treated as molecules, so the residue names must be unique for each different molecule [1, 2, 13-17].\n",
+    "\n",
+    "## Note: When importing mol2 files, the residue names (pentane.name and hexane.name), must be the same name as in the mol2 file."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 27,
+   "execution_count": null,
    "id": "future-walker",
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "/Users/brad/Programs/anaconda3/envs/GOMC_MOSDEF/lib/python3.9/site-packages/ipykernel/ipkernel.py:283: DeprecationWarning: `should_run_async` will not call `transform_cell` automatically in the future. Please pass the result to `transformed_cell` argument and any exception that happen during thetransform in `preprocessing_exc_tuple` in IPython 7.17 and above.\n",
-      "  and should_run_async(code)\n",
-      "/Users/brad/Programs/anaconda3/envs/GOMC_MOSDEF/lib/python3.9/site-packages/foyer/forcefield.py:472: UserWarning: Non-atomistic element type detected. Creating custom element for _CH4\n",
-      "  warnings.warn('Non-atomistic element type detected. '\n",
-      "/Users/brad/Programs/anaconda3/envs/GOMC_MOSDEF/lib/python3.9/site-packages/foyer/forcefield.py:472: UserWarning: Non-atomistic element type detected. Creating custom element for _CH3\n",
-      "  warnings.warn('Non-atomistic element type detected. '\n",
-      "/Users/brad/Programs/anaconda3/envs/GOMC_MOSDEF/lib/python3.9/site-packages/foyer/forcefield.py:472: UserWarning: Non-atomistic element type detected. Creating custom element for _CH2\n",
-      "  warnings.warn('Non-atomistic element type detected. '\n",
-      "/Users/brad/Programs/anaconda3/envs/GOMC_MOSDEF/lib/python3.9/site-packages/foyer/forcefield.py:472: UserWarning: Non-atomistic element type detected. Creating custom element for _HC\n",
-      "  warnings.warn('Non-atomistic element type detected. '\n",
-      "/Users/brad/Programs/anaconda3/envs/GOMC_MOSDEF/lib/python3.9/site-packages/foyer/forcefield.py:448: UserWarning: No force field version number found in force field XML file.\n",
-      "  warnings.warn(\n",
-      "/Users/brad/Programs/anaconda3/envs/GOMC_MOSDEF/lib/python3.9/site-packages/foyer/forcefield.py:460: UserWarning: No force field name found in force field XML file.\n",
-      "  warnings.warn(\n",
-      "/Users/brad/Programs/anaconda3/envs/GOMC_MOSDEF/lib/python3.9/site-packages/mbuild/compound.py:1642: UserWarning: OpenMM Force CustomNonbondedForce is not currently supported in _energy_minimize_openmm. This Force will not be updated!\n",
-      "  warn(\n",
-      "/Users/brad/Programs/anaconda3/envs/GOMC_MOSDEF/lib/python3.9/site-packages/foyer/forcefield.py:472: UserWarning: Non-atomistic element type detected. Creating custom element for _CH4\n",
-      "  warnings.warn('Non-atomistic element type detected. '\n",
-      "/Users/brad/Programs/anaconda3/envs/GOMC_MOSDEF/lib/python3.9/site-packages/foyer/forcefield.py:472: UserWarning: Non-atomistic element type detected. Creating custom element for _CH3\n",
-      "  warnings.warn('Non-atomistic element type detected. '\n",
-      "/Users/brad/Programs/anaconda3/envs/GOMC_MOSDEF/lib/python3.9/site-packages/foyer/forcefield.py:472: UserWarning: Non-atomistic element type detected. Creating custom element for _CH2\n",
-      "  warnings.warn('Non-atomistic element type detected. '\n",
-      "/Users/brad/Programs/anaconda3/envs/GOMC_MOSDEF/lib/python3.9/site-packages/foyer/forcefield.py:472: UserWarning: Non-atomistic element type detected. Creating custom element for _HC\n",
-      "  warnings.warn('Non-atomistic element type detected. '\n",
-      "/Users/brad/Programs/anaconda3/envs/GOMC_MOSDEF/lib/python3.9/site-packages/foyer/forcefield.py:448: UserWarning: No force field version number found in force field XML file.\n",
-      "  warnings.warn(\n",
-      "/Users/brad/Programs/anaconda3/envs/GOMC_MOSDEF/lib/python3.9/site-packages/foyer/forcefield.py:460: UserWarning: No force field name found in force field XML file.\n",
-      "  warnings.warn(\n",
-      "/Users/brad/Programs/anaconda3/envs/GOMC_MOSDEF/lib/python3.9/site-packages/mbuild/compound.py:1642: UserWarning: OpenMM Force CustomNonbondedForce is not currently supported in _energy_minimize_openmm. This Force will not be updated!\n",
-      "  warn(\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "pentane = mb.load('../common/pentane.mol2')\n",
     "pentane.name = 'PEN'\n",
@@ -126,21 +82,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 28,
+   "execution_count": null,
    "id": "unsigned-inspiration",
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "/Users/brad/Programs/anaconda3/envs/GOMC_MOSDEF/lib/python3.9/site-packages/ipykernel/ipkernel.py:283: DeprecationWarning: `should_run_async` will not call `transform_cell` automatically in the future. Please pass the result to `transformed_cell` argument and any exception that happen during thetransform in `preprocessing_exc_tuple` in IPython 7.17 and above.\n",
-      "  and should_run_async(code)\n",
-      "/Users/brad/Programs/anaconda3/envs/GOMC_MOSDEF/lib/python3.9/site-packages/mbuild/formats/xyz.py:63: UserWarning: No matching element found for _CH; the particle will be added to the compound without an element attribute.\n",
-      "  warn(\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "pentane_hexane_box_liq = mb.fill_box(compound=molecule_list,\n",
     "                                     density=liquid_box_density_kg_per_m_cubed,\n",
@@ -161,43 +106,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 29,
+   "execution_count": null,
    "id": "passive-bracket",
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "/Users/brad/Programs/anaconda3/envs/GOMC_MOSDEF/lib/python3.9/site-packages/ipykernel/ipkernel.py:283: DeprecationWarning: `should_run_async` will not call `transform_cell` automatically in the future. Please pass the result to `transformed_cell` argument and any exception that happen during thetransform in `preprocessing_exc_tuple` in IPython 7.17 and above.\n",
-      "  and should_run_async(code)\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "write_gomcdata: forcefield_selection = trappe-ua, residues = ['PEN', 'HEX']\n",
-      "FF forcefield_selection = {'PEN': 'trappe-ua', 'HEX': 'trappe-ua'}\n",
-      "******************************\n",
-      "\n",
-      "GOMC FF writing each residues FF as a group for structure_box_0\n",
-      "forcefield_selection = {'PEN': 'trappe-ua', 'HEX': 'trappe-ua'}\n",
-      "forcefield type from compound = {'PEN': 'trappe-ua', 'HEX': 'trappe-ua'}\n",
-      "coulomb14scale from compound = {'PEN': 0.0, 'HEX': 0.0}\n",
-      "lj14scale from compound = {'PEN': 0.0, 'HEX': 0.0}\n",
-      "all_res_unique_atom_name_dict = {'PEN': ['BD1', 'BD2', 'BD3', 'BD4', 'BD5'], 'HEX': ['BD1', 'BD2', 'BD3', 'BD4', 'BD5', 'BD6']}\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "/Users/brad/Programs/anaconda3/envs/GOMC_MOSDEF/lib/python3.9/site-packages/mbuild/formats/charmm_writer.py:836: UserWarning: NOTE: All bead names were not found in the Bead to atom naming dictionary (bead_to_atom_name_dict) \n",
-      "  warn(\"NOTE: All bead names were not found in the Bead to atom naming dictionary (bead_to_atom_name_dict) \")\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "charmm = mf_charmm.Charmm(pentane_hexane_box_liq,\n",
     "                          'NVT_pentane_hexane_liq',\n",
@@ -219,78 +131,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 30,
+   "execution_count": null,
    "id": "recovered-gossip",
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "/Users/brad/Programs/anaconda3/envs/GOMC_MOSDEF/lib/python3.9/site-packages/ipykernel/ipkernel.py:283: DeprecationWarning: `should_run_async` will not call `transform_cell` automatically in the future. Please pass the result to `transformed_cell` argument and any exception that happen during thetransform in `preprocessing_exc_tuple` in IPython 7.17 and above.\n",
-      "  and should_run_async(code)\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "******************************\n",
-      "\n",
-      "The charmm force field file writer (the write_inp function) is running\n",
-      "******************************\n",
-      "\n",
-      "The charmm force field file writer (the write_inp function) is running\n",
-      "******************************\n",
-      "\n",
-      "writing the GOMC force field file \n",
-      "No urey bradley terms detected, will use angle_style harmonic\n",
-      "will use CHARMM_torsions  =  K0 + K1 * (1 + Cos[n1*(t) - (d1)] ) + K2 * (1 + Cos[n2*(t) - (d2)] ) + K3 * (1 + Cos[n3*(t) - (d3)] ) + K4 * (1 + Cos[n4*(t) - (d4)] ) + K5 * (1 + Cos[n5*(t) - (d5)] ) \n",
-      "! RB-torsion to CHARMM dihedral conversion error is OK [error <= 10^(-10)]\n",
-      "! Maximum( |(RB-torsion calc)-(CHARMM dihedral calc)| ) =  1.2878587085651816e-14\n",
-      "\n",
-      "NBFIX_Mixing not used or no mixing used for the non-bonded potentials out\n",
-      "self.non_bonded_type = LJ\n",
-      "forcefield_dict = {3: 'CH3_sp3_PEN', 1: 'CH2_sp3_PEN', 2: 'CH3_sp3_HEX', 0: 'CH2_sp3_HEX'}\n",
-      "******************************\n",
-      "\n",
-      "The charmm X-plor format psf writer (the write_psf function) is running\n",
-      "write_psf: forcefield_selection = {'PEN': 'trappe-ua', 'HEX': 'trappe-ua'}, residues = ['PEN', 'HEX']\n",
-      "******************************\n",
-      "\n",
-      "No urey bradley terms detected\n",
-      "RB Torsions detected, will converted to CHARMM Dihedrals\n",
-      "bead_to_atom_name_dict = None\n",
-      "******************************\n",
-      "\n",
-      "The charmm pdb writer (the write_pdb function) is running\n",
-      "write_charmm_pdb: residues == ['PEN', 'HEX']\n",
-      "fix_residue = None\n",
-      "fix_residue_in_box = None\n",
-      "bead_to_atom_name_dict = None\n",
-      "INFORMATION: No atoms are fixed in this pdb file for the GOMC simulation engine. \n",
-      "******************************\n",
-      "\n",
-      "INFO: ensemble_type = NVT\n",
-      "INFO: All the ensemble (ensemble_type) input passed the intial error checking\n",
-      "INFO: All the Temperature  (Temperature) input passed the initial error checking\n",
-      "INFO: All the required force field, pdb, and psf files for box 0 and 1 (.inp, .pdb, and .psf) all passed the intial error checking. Note: the file names and their existance is not confirmed.\n",
-      "INFO: All the input variable passed the intial error checking\n",
-      "INFO: The sum of the Monte Carlo move ratios = 1.000000000000\n",
-      "INFO: the correct extension for the control file was provided in the file name, .conf with control file name = in_NVT.conf\n"
-     ]
-    },
-    {
-     "data": {
-      "text/plain": [
-       "'GOMC_CONTROL_FILE_WRITTEN'"
-      ]
-     },
-     "execution_count": 30,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "charmm.write_inp()\n",
     "\n",
@@ -325,7 +169,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },
@@ -339,7 +183,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.1"
+   "version": "3.10.0"
   }
  },
  "nbformat": 4,

--- a/MoSDef-GOMC/Part_6_NVT_Example/NVT_Example_pentane_hexane.py
+++ b/MoSDef-GOMC/Part_6_NVT_Example/NVT_Example_pentane_hexane.py
@@ -21,9 +21,10 @@ hexane_mol_ratio = 0.5
 # Generate the lists for the molecules, residues, and mol ratios,
 # residues/molecules force fields [1, 2, 13-17].
 
-## Note: For GOMC, the residue names are treated as molecules,
+# Note: For GOMC, the residue names are treated as molecules,
 # so the residue names must be unique for each different molecule [1, 2, 13-17].
 
+# Note: When importing mol2 files, the residue names (pentane.name and hexane.name), must be the same name as in the mol2 file.
 
 pentane = mb.load('../common/pentane.mol2')
 pentane.name = 'PEN'

--- a/MoSDef-GOMC/Part_6_NVT_Example/NVT_Example_pentane_hexane_gmso.ipynb
+++ b/MoSDef-GOMC/Part_6_NVT_Example/NVT_Example_pentane_hexane_gmso.ipynb
@@ -46,7 +46,9 @@
     "\n",
     "# Generate the lists for the molecules, residues, and mol ratios,  residues/molecules force fields [1, 2, 13-17].  \n",
     "\n",
-    "## Note: For GOMC, the residue names are treated as molecules, so the residue names must be unique for each different molecule [1, 2, 13-17]."
+    "## Note: For GOMC, the residue names are treated as molecules, so the residue names must be unique for each different molecule [1, 2, 13-17].\n",
+    "\n",
+    "## Note: When importing mol2 files, the residue names (pentane.name and hexane.name), must be the same name as in the mol2 file."
    ]
   },
   {
@@ -174,7 +176,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.12"
+   "version": "3.10.0"
   }
  },
  "nbformat": 4,

--- a/MoSDef-GOMC/Part_6_NVT_Example/NVT_Example_pentane_hexane_gmso.py
+++ b/MoSDef-GOMC/Part_6_NVT_Example/NVT_Example_pentane_hexane_gmso.py
@@ -25,6 +25,7 @@ hexane_mol_ratio = 0.5
 ## Note: For GOMC, the residue names are treated as molecules,
 # so the residue names must be unique for each different molecule [1, 2, 13-17].
 
+# Note: When importing mol2 files, the residue names (pentane.name and hexane.name), must be the same name as in the mol2 file.
 
 pentane = mb.load('../common/pentane.mol2')
 pentane.name = 'PEN'

--- a/MoSDef-GOMC/Part_7_water_TIP4P_2005_NPT_Example/NPT_Example_water_TIP4P_2005_FF.ipynb
+++ b/MoSDef-GOMC/Part_7_water_TIP4P_2005_NPT_Example/NPT_Example_water_TIP4P_2005_FF.ipynb
@@ -43,7 +43,9 @@
     "\n",
     "## Note: For GOMC, the residue names are treated as molecules, so the residue names must be unique for each different molecule [1, 2, 13-17]. The force field (FF) dictionary (forcefield_files variable) can set each residue with a different FF, by the FF name (via the foyer FF repository) or a specified FF xml file [1, 2, 13-17].\n",
     "\n",
-    "## NOTE: The exact bond, angle, and configuration (i.e., a planar water) must be set in the .mol2 file [1, 2, 13-17]. When using a TIP4P water, minimizing the structure here could result in the lone pair being pushed in out of plane [1, 2, 13-17]. Therefore, if you need to minimize the sytem, we recommend minimizing it in an engine that takes that into consideration [1, 2, 13-17]."
+    "## NOTE: The exact bond, angle, and configuration (i.e., a planar water) must be set in the .mol2 file [1, 2, 13-17]. When using a TIP4P water, minimizing the structure here could result in the lone pair being pushed in out of plane [1, 2, 13-17]. Therefore, if you need to minimize the sytem, we recommend minimizing it in an engine that takes that into consideration [1, 2, 13-17].\n",
+    "\n",
+    "## Note: When importing mol2 files, the residue names (water.name), must be the same name as in the mol2 file."
    ]
   },
   {
@@ -179,7 +181,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.12"
+   "version": "3.10.0"
   }
  },
  "nbformat": 4,

--- a/MoSDef-GOMC/Part_7_water_TIP4P_2005_NPT_Example/NPT_Example_water_TIP4P_2005_FF.py
+++ b/MoSDef-GOMC/Part_7_water_TIP4P_2005_NPT_Example/NPT_Example_water_TIP4P_2005_FF.py
@@ -27,6 +27,8 @@ Liquid_box_Total_molecules = 1100
 # Therefore, if you need to minimize the sytem, we recommend minimizing it in an engine that takes that
 # into consideration [1, 2, 13-17].
 
+# Note: When importing mol2 files, the residue names (water.name), must be the same name as in the mol2 file.
+
 forcefield_files_water = '../common/tip4p_2005_oplsaa.xml'
 water = mb.load('../common/tip4p_2005.mol2')
 water.name = 'H2O'

--- a/MoSDef-GOMC/Part_7_water_TIP4P_2005_NPT_Example/NPT_Example_water_TIP4P_2005_FF_gmso.ipynb
+++ b/MoSDef-GOMC/Part_7_water_TIP4P_2005_NPT_Example/NPT_Example_water_TIP4P_2005_FF_gmso.ipynb
@@ -43,7 +43,9 @@
     "\n",
     "## Note: For GOMC, the residue names are treated as molecules, so the residue names must be unique for each different molecule [1, 2, 13-17]. The force field (FF) dictionary (forcefield_files variable) can set each residue with a different FF, by the FF name (via the foyer FF repository) or a specified FF xml file [1, 2, 13-17].\n",
     "\n",
-    "## NOTE: The exact bond, angle, and configuration (i.e., a planar water) must be set in the .mol2 file [1, 2, 13-17]. When using a TIP4P water, minimizing the structure here could result in the lone pair being pushed in out of plane [1, 2, 13-17]. Therefore, if you need to minimize the sytem, we recommend minimizing it in an engine that takes that into consideration [1, 2, 13-17]."
+    "## NOTE: The exact bond, angle, and configuration (i.e., a planar water) must be set in the .mol2 file [1, 2, 13-17]. When using a TIP4P water, minimizing the structure here could result in the lone pair being pushed in out of plane [1, 2, 13-17]. Therefore, if you need to minimize the sytem, we recommend minimizing it in an engine that takes that into consideration [1, 2, 13-17].\n",
+    "\n",
+    "## Note: When importing mol2 files, the residue names (water.name), must be the same name as in the mol2 file."
    ]
   },
   {
@@ -179,7 +181,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.12"
+   "version": "3.10.0"
   }
  },
  "nbformat": 4,

--- a/MoSDef-GOMC/Part_7_water_TIP4P_2005_NPT_Example/NPT_Example_water_TIP4P_2005_FF_gmso.py
+++ b/MoSDef-GOMC/Part_7_water_TIP4P_2005_NPT_Example/NPT_Example_water_TIP4P_2005_FF_gmso.py
@@ -27,6 +27,8 @@ Liquid_box_Total_molecules = 1100
 # Therefore, if you need to minimize the sytem, we recommend minimizing it in an engine that takes that
 # into consideration [1, 2, 13-17].
 
+# Note: When importing mol2 files, the residue names (water.name), must be the same name as in the mol2 file.
+
 forcefield_files_water = '../common/tip4p_2005_oplsaa.xml'
 water = mb.load('../common/tip4p_2005.mol2')
 water.name = 'H2O'

--- a/MoSDef-GOMC/Part_8_neon_free_energy_in_cyclohexane_NPT_Example/NPT_neon_free_energy_in_cyclohexane.ipynb
+++ b/MoSDef-GOMC/Part_8_neon_free_energy_in_cyclohexane_NPT_Example/NPT_neon_free_energy_in_cyclohexane.ipynb
@@ -46,7 +46,9 @@
     "\n",
     "# Make the dictionaries to customize the bead's atoms names, and set the residues/molecules force fields [1, 2, 13-17].\n",
     "\n",
-    "## Note: For GOMC, the residue names are treated as molecules, so the residue names must be unique for each different molecule [1, 2, 13-17]. The force field (FF) dictionary (forcefield_files variable) can set each residue with a different FF, by the FF name (via the foyer FF repository) or a specified FF xml file [1, 2, 13-17]."
+    "## Note: For GOMC, the residue names are treated as molecules, so the residue names must be unique for each different molecule [1, 2, 13-17]. The force field (FF) dictionary (forcefield_files variable) can set each residue with a different FF, by the FF name (via the foyer FF repository) or a specified FF xml file [1, 2, 13-17].\n",
+    "\n",
+    "## Note: When importing mol2 files, the residue names (cyclohexane.name) must be the same name as in the mol2 file."
    ]
   },
   {
@@ -385,7 +387,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.12"
+   "version": "3.10.0"
   }
  },
  "nbformat": 4,

--- a/MoSDef-GOMC/Part_8_neon_free_energy_in_cyclohexane_NPT_Example/NPT_neon_free_energy_in_cyclohexane.py
+++ b/MoSDef-GOMC/Part_8_neon_free_energy_in_cyclohexane_NPT_Example/NPT_neon_free_energy_in_cyclohexane.py
@@ -24,6 +24,8 @@ liquid_box_cyclohexane_molecules = 300
 # with a different FF, by the FF name (via the foyer FF repository)
 # or a specified FF xml file [1, 2, 13-17].
 
+# Note: When importing mol2 files, the residue names (cyclohexane.name) must be the same name as in the mol2 file.
+
 forcefield_files_neon = '../common/neon_LB_mixing.xml'
 neon = mb.Compound(name="Ne")
 

--- a/MoSDef-GOMC/Part_8_neon_free_energy_in_cyclohexane_NPT_Example/NPT_neon_free_energy_in_cyclohexane_gmso.ipynb
+++ b/MoSDef-GOMC/Part_8_neon_free_energy_in_cyclohexane_NPT_Example/NPT_neon_free_energy_in_cyclohexane_gmso.ipynb
@@ -46,7 +46,9 @@
     "\n",
     "# Make the dictionaries to customize the bead's atoms names, and set the residues/molecules force fields [1, 2, 13-17].\n",
     "\n",
-    "## Note: For GOMC, the residue names are treated as molecules, so the residue names must be unique for each different molecule [1, 2, 13-17]. The force field (FF) dictionary (forcefield_files variable) can set each residue with a different FF, by the FF name (via the foyer FF repository) or a specified FF xml file [1, 2, 13-17]."
+    "## Note: For GOMC, the residue names are treated as molecules, so the residue names must be unique for each different molecule [1, 2, 13-17]. The force field (FF) dictionary (forcefield_files variable) can set each residue with a different FF, by the FF name (via the foyer FF repository) or a specified FF xml file [1, 2, 13-17].\n",
+    "\n",
+    "## Note: When importing mol2 files, the residue names (cyclohexane.name) must be the same name as in the mol2 file."
    ]
   },
   {
@@ -399,7 +401,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.12"
+   "version": "3.10.0"
   }
  },
  "nbformat": 4,

--- a/MoSDef-GOMC/Part_8_neon_free_energy_in_cyclohexane_NPT_Example/NPT_neon_free_energy_in_cyclohexane_gmso.py
+++ b/MoSDef-GOMC/Part_8_neon_free_energy_in_cyclohexane_NPT_Example/NPT_neon_free_energy_in_cyclohexane_gmso.py
@@ -24,6 +24,8 @@ liquid_box_cyclohexane_molecules = 300
 # with a different FF, by the FF name (via the foyer FF repository)
 # or a specified FF xml file [1, 2, 13-17].
 
+# Note: When importing mol2 files, the residue names (cyclohexane.name) must be the same name as in the mol2 file.
+
 forcefield_files_neon = '../common/neon_LB_mixing.xml'
 neon = mb.Compound(name="Ne")
 

--- a/MoSDef-GOMC/common/gmso_hexane_Exp6_periodic_dihedral_ua_K_energy_units.xml
+++ b/MoSDef-GOMC/common/gmso_hexane_Exp6_periodic_dihedral_ua_K_energy_units.xml
@@ -1,0 +1,103 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<ForceField name="Exp6 hexane - This is for testing only and not for use for simulations " version="0.0.1">
+  <FFMetaData electrostatics14Scale="0.0" nonBonded14Scale="0.0" combiningRule="lorentz">
+    <Units energy="kcal/mol" mass="amu" charge="elementary_charge" distance="angstrom"/>
+  </FFMetaData>
+  <AtomTypes expression="epsilon*alpha/(alpha-6) * (6/alpha*exp(alpha*(1-r/Rmin)) - (Rmin/r)**6)">
+    <ParametersUnitDef parameter="epsilon" unit="K"/>
+    <ParametersUnitDef parameter="Rmin" unit="angstrom"/>
+    <ParametersUnitDef parameter="alpha" unit="dimensionless"/>
+    <AtomType name="CH3_sp3" atomclass="CH3" element="_CH3" charge="0.0" mass="15.03500" definition="[_CH3;X1][_CH3,_CH2]"  description="Alkane CH3" doi="10.1021/jp984742e and 10.1021/jp972543+" overrides="">
+      <Parameters>
+        <Parameter name="epsilon" value="98"/>
+        <Parameter name="Rmin" value="4.0941137"/>
+        <Parameter name="alpha" value="16"/>
+      </Parameters>
+    </AtomType>
+    <AtomType name="CH2_sp3" atomclass="CH2" element="_CH2" charge="0.0" mass="14.02700" definition="[_CH2;X2]([_CH3,_CH2])[_CH3,_CH2]" description="Alkane CH2" overrides="">
+      <Parameters>
+        <Parameter name="epsilon" value="98"/>
+        <Parameter name="Rmin" value="4.0941137"/>
+        <Parameter name="alpha" value="16"/>
+      </Parameters>
+    </AtomType>
+  </AtomTypes>
+  <BondTypes expression="k * (r-r_eq)**2">
+    <ParametersUnitDef parameter="r_eq" unit="angstrom"/>
+    <ParametersUnitDef parameter="k" unit="K/angstrom**2"/>
+    <BondType name="BondType_Harmonic_CH3_CH3" class1="CH3" class2="CH3">
+      <Parameters>
+        <Parameter name="k" value="604267.555311465"/>
+        <Parameter name="r_eq" value="1.839"/>
+      </Parameters>
+    </BondType>
+    <BondType name="BondType_Harmonic_CH3_CH2" class1="CH3" class2="CH2">
+      <Parameters>
+        <Parameter name="k" value="604267.555311465"/>
+        <Parameter name="r_eq" value="1.687"/>
+      </Parameters>
+    </BondType>
+    <BondType name="BondType_Harmonic_CH2_CH2" class1="CH2" class2="CH2">
+      <Parameters>
+        <Parameter name="k" value="604267.555311465"/>
+        <Parameter name="r_eq" value="1.535"/>
+      </Parameters>
+    </BondType>
+  </BondTypes>
+  <AngleTypes expression="k * (theta - theta_eq)**2">
+    <ParametersUnitDef parameter="theta_eq" unit="degree"/>
+    <ParametersUnitDef parameter="k" unit="K/radian**2"/>
+    <AngleType name="AngleType_Harmonic_CH3_CH2_CH2" class1="CH3" class2="CH2" class3="CH3">
+      <Parameters>
+        <Parameter name="k" value="62500"/>
+        <Parameter name="theta_eq" value="114"/>
+      </Parameters>
+    </AngleType>
+   <AngleType name="AngleType_Harmonic_CH3_CH2_CH3" class1="CH2" class2="CH2" class3="CH3">
+      <Parameters>
+        <Parameter name="k" value="62500"/>
+        <Parameter name="theta_eq" value="114"/>
+      </Parameters>
+    </AngleType>
+    <AngleType name="AngleType_Harmonic_CH2_CH2_CH2" class1="CH2" class2="CH2" class3="CH2">
+      <Parameters>
+        <Parameter name="k" value="62500"/>
+        <Parameter name="theta_eq" value="114"/>
+      </Parameters>
+    </AngleType>
+  </AngleTypes>
+  <DihedralTypes expression="0.5 * k0 + 0.5 * k1 * (1 + cos(phi)) + 0.5 * k2 * (1 - cos(2*phi)) + 0.5 * k3 * (1 + cos(3*phi)) + 0.5 * k4 * (1 - cos(4*phi))">
+    <ParametersUnitDef parameter="k0" unit="K"/>
+    <ParametersUnitDef parameter="k1" unit="K"/>
+    <ParametersUnitDef parameter="k2" unit="K"/>
+    <ParametersUnitDef parameter="k3" unit="K"/>
+    <ParametersUnitDef parameter="k4" unit="K"/>
+    <DihedralType name="DihedralType_RB_Proper_CH3_CH2_CH2_CH3" class1="CH3" class2="CH2" class3="CH2" class4="CH3">
+      <Parameters>
+        <Parameter name="k0" value="0.0"/>
+        <Parameter name="k1" value="355.03"/>
+        <Parameter name="k2" value="-68.19"/>
+        <Parameter name="k3" value="791.32"/>
+        <Parameter name="k4" value="0.0"/>
+      </Parameters>
+    </DihedralType>
+    <DihedralType name="DihedralType_RB_Proper_CH3_CH2_CH2_CH2" class1="CH3" class2="CH2" class3="CH2" class4="CH2">
+      <Parameters>
+        <Parameter name="k0" value="0.0"/>
+        <Parameter name="k1" value="355.03"/>
+        <Parameter name="k2" value="-68.19"/>
+        <Parameter name="k3" value="791.32"/>
+        <Parameter name="k4" value="0.0"/>
+      </Parameters>
+    </DihedralType>
+    <DihedralType name="DihedralType_RB_Proper_CH2_CH2_CH2_CH2" class1="CH2" class2="CH2" class3="CH2" class4="CH2">
+      <Parameters>
+        <Parameter name="k0" value="0.0"/>
+        <Parameter name="k1" value="355.03"/>
+        <Parameter name="k2" value="-68.19"/>
+        <Parameter name="k3" value="791.32"/>
+        <Parameter name="k4" value="0.0"/>
+      </Parameters>
+    </DihedralType>
+  </DihedralTypes>
+</ForceField>


### PR DESCRIPTION
Added Exp6 FF example and notes to all files using mol2 that the residue name must be entered the same as the as in the mol2 file.

This will now be the example for the mosdef-gomc package, which now includes the Exp6 potential